### PR TITLE
fixed form3 bug when records return empty

### DIFF
--- a/server/queries/getData/getLeadId.js
+++ b/server/queries/getData/getLeadId.js
@@ -10,7 +10,7 @@ const getLeadId = ({ emailAddress }) => {
       }).firstPage((err, records) => {
         if (err) {
           reject(new Error('Server Error'));
-        } else if (records) {
+        } else if (records.length) {
           resolve(records[0].id);
         } else {
           reject(new Error('Every new user should have a lead'));


### PR DESCRIPTION
An empty array returns truthy. This was preventing our promise from rejecting the error